### PR TITLE
properly escape the output

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -42,5 +42,7 @@ fi
 echo "keyword detected: $result"
 echo "::endgroup::"
 
-echo "::set-output name=COMMIT_MESSAGE::$commit_message"
+escaped=$(echo -n $commit_message | python -c 'import sys; from urllib.parse import quote; print(quote(sys.stdin.read()))')
+
+echo "::set-output name=COMMIT_MESSAGE::$escaped"
 echo "::set-output name=CI_TRIGGERED::$result"

--- a/script.sh
+++ b/script.sh
@@ -42,7 +42,7 @@ fi
 echo "keyword detected: $result"
 echo "::endgroup::"
 
-escaped_message="$(echo $commit_message | tr '"' '%22')"
+escaped_message="$(echo $commit_message | sed 's/\"/\\"/g')"
 echo "commit message: '$commit_message'"
 echo "escaped message: '$escaped_message'"
 echo "::set-output name=COMMIT_MESSAGE::$escaped_message"

--- a/script.sh
+++ b/script.sh
@@ -42,5 +42,8 @@ fi
 echo "keyword detected: $result"
 echo "::endgroup::"
 
-echo "::set-output name=COMMIT_MESSAGE::$(echo $commit_message | tr '"' '%22')"
+escaped_message="$(echo $commit_message | tr '"' '%22')"
+echo "commit message: '$commit_message'"
+echo "escaped message: '$escaped_message'"
+echo "::set-output name=COMMIT_MESSAGE::$escaped_message"
 echo "::set-output name=CI_TRIGGERED::$result"

--- a/script.sh
+++ b/script.sh
@@ -42,7 +42,5 @@ fi
 echo "keyword detected: $result"
 echo "::endgroup::"
 
-escaped=$(echo -n $commit_message | python -c 'import sys; from urllib.parse import quote; print(quote(sys.stdin.read()))')
-
-echo "::set-output name=COMMIT_MESSAGE::$escaped"
+echo "::set-output name=COMMIT_MESSAGE::$(echo $commit_message | tr '"' '\"')"
 echo "::set-output name=CI_TRIGGERED::$result"

--- a/script.sh
+++ b/script.sh
@@ -42,5 +42,5 @@ fi
 echo "keyword detected: $result"
 echo "::endgroup::"
 
-echo "::set-output name=COMMIT_MESSAGE::$(echo $commit_message | tr '"' '\"')"
+echo "::set-output name=COMMIT_MESSAGE::$(echo $commit_message | tr '"' '%22')"
 echo "::set-output name=CI_TRIGGERED::$result"

--- a/script.sh
+++ b/script.sh
@@ -42,8 +42,5 @@ fi
 echo "keyword detected: $result"
 echo "::endgroup::"
 
-escaped_message="$(echo $commit_message | sed 's/\"/\\"/g')"
-echo "commit message: '$commit_message'"
-echo "escaped message: '$escaped_message'"
-echo "::set-output name=COMMIT_MESSAGE::$escaped_message"
+echo "::set-output name=COMMIT_MESSAGE::$(echo $commit_message | sed 's/\"/\\"/g')"
 echo "::set-output name=CI_TRIGGERED::$result"


### PR DESCRIPTION
This properly escapes double quotes (`"`) in the commit message so characters interpreted by bash (e.g. `<`, `!`) are still within the quotes.