### PR TITLE
replace the deprecated set-output with the new environment files

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -42,5 +42,5 @@ fi
 echo "keyword detected: $result"
 echo "::endgroup::"
 
-echo "::set-output name=COMMIT_MESSAGE::$(echo $commit_message | sed 's/\"/\\"/g')"
-echo "::set-output name=CI_TRIGGERED::$result"
+echo "COMMIT_MESSAGE=$(echo $commit_message | sed 's/\"/\\"/g')" >> $GITHUB_OUTPUT
+echo "CI_TRIGGERED=$result" >> $GITHUB_OUTPUT


### PR DESCRIPTION
See the [changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for more information.